### PR TITLE
Set environment*.ts to .gitignore because of api keys

### DIFF
--- a/src/environments/.gitignore
+++ b/src/environments/.gitignore
@@ -1,0 +1,1 @@
+environment*.ts


### PR DESCRIPTION
Firebase API keys are visible at https://github.com/canyaio/CANInvoice/blob/master/src/environments/environment.prod.ts. Pull request adds .gitignore but does not remove them, as they should be deleted from git history permanently.